### PR TITLE
Verifica por wrapper do Composer no projeto

### DIFF
--- a/resources/scripts/deploy/steps/InstallComposerDependencies.sh
+++ b/resources/scripts/deploy/steps/InstallComposerDependencies.sh
@@ -22,6 +22,11 @@ if [ -f {{ release_path }}/composer.json ]; then
         fi
     fi
 
+    # Composer Wrapper Checker
+    if [ -x "{{ release_path }}/composer.sh" ]; then
+        composer="{{ release_path }}/composer.sh"
+    fi
+
     cd {{ release_path }}
 
     if [ -n "{{ include_dev }}" ]; then


### PR DESCRIPTION
Verifica se existe um arquivo `composer.sh` e utiliza-o como o Composer da instalação. Possibilita que o projeto possua um Composer especializado como Wrapper.